### PR TITLE
add breadcrumb CSS

### DIFF
--- a/lib/sass/fear-core-ui/templates/_breadcrumb.scss
+++ b/lib/sass/fear-core-ui/templates/_breadcrumb.scss
@@ -1,0 +1,32 @@
+
+.breadcrumb-holder {
+  @include media-query-max-xsmall {
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+  }
+}
+
+.breadcrumb {
+  @extend %clearfix;
+  @include rem(margin, 19px 0 17px 0);
+  padding: 0;
+  list-style: none;
+
+  li {
+    @include rem(padding, 0 6px);
+    @include rem(margin, 0 0 0 0);
+    float: left;
+    border-left: 2px solid $color__brand--dark-grey;
+  }
+
+  a {
+    vertical-align: text-top;
+  }
+
+  li:first-child {
+    @include rem(padding, 0 6px 0 0);
+    border: 0;
+  }
+}


### PR DESCRIPTION
Hides breadcrumb at lower breakpoints
Avoids use of `display: none;` to keep breadcrumb visible to screen readers