### PR TITLE
Hide accessibilty text from left instead of top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # fear-core-ui change log
 
+#### **4.0.2**
+- hide accessibility text from left instead of top
+
 #### **4.0.1**
 - new font assets - fixes 1/2 and 1/4 reversal
 

--- a/lib/sass/fear-core-ui/utilities/accessability/_module_accessibility.scss
+++ b/lib/sass/fear-core-ui/utilities/accessability/_module_accessibility.scss
@@ -7,7 +7,7 @@
 .acc__header,
 .acc__text {
   position: absolute;
-  top: -9999px;
+  left: -99999px;
 }
 
 // Remove visible styling for the accessibility links list


### PR DESCRIPTION
As the PD page gets very long with an unknown amount of reviews, the accessibility text is coming into visibility on screen. Can we hide these from the left as there will be limited screen width compared to height in most scenarios?